### PR TITLE
Remove unused IUPAC import which causes crash

### DIFF
--- a/fastqe/fastqe.py
+++ b/fastqe/fastqe.py
@@ -24,7 +24,6 @@ import numpy as np
 from Bio import SeqIO
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
-from Bio.Alphabet import IUPAC
 from Bio.SeqIO import QualityIO
 from . import fastqe_map as emaps # todo make maps illumin 1.9 specific etc
 import os


### PR DESCRIPTION
```
ImportError: Bio.Alphabet has been removed from Biopython. In many cases, the alphabet can simply be ignored and removed from scripts. In a few cases, you may need to specify the ``molecule_type`` as an annotation on a SeqRecord for your script to work correctly. Please see https://biopython.org/wiki/Alphabet for more information.
```

this was [removed in 1.78](https://biopython.org/wiki/Alphabet)